### PR TITLE
Enhancement: Docker composer limits

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,6 +14,10 @@ services:
     depends_on:
       postgres_test:
         condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 2G
     entrypoint: ['./docker/entrypoint.sh']
     environment:
       MIX_ENV: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: 1
+          # it uses less than 100 MB but it is required for the first compilation and about 1.5GB for dialyzer
           memory: 4G
     entrypoint: ['./docker/entrypoint.sh']
     environment:


### PR DESCRIPTION
Why is the PR required?

Adds docker compose memory limit explanation and sets a limit for compose test file.