### PR TITLE
Refactor: users function naming

### DIFF
--- a/lib/bank/users.ex
+++ b/lib/bank/users.ex
@@ -27,12 +27,12 @@ defmodule Bank.Users do
 
   ## Examples
 
-      iex> change_user_password(user)
+      iex> change_password(user)
       %Ecto.Changeset{data: %User{}}
 
   """
-  @spec change_user_password(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
-  def change_user_password(user, attrs \\ %{}) do
+  @spec change_password(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
+  def change_password(user, attrs \\ %{}) do
     User.password_changeset(user, attrs, hash_password: false)
   end
 
@@ -41,12 +41,12 @@ defmodule Bank.Users do
 
   ## Examples
 
-      iex> change_user_registration(user)
+      iex> change_registration(user)
       %Ecto.Changeset{data: %User{}}
 
   """
-  @spec change_user_registration(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
-  def change_user_registration(%User{} = user, attrs \\ %{}) do
+  @spec change_registration(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
+  def change_registration(%User{} = user, attrs \\ %{}) do
     User.registration_changeset(user, attrs, hash_password: false, validate_email: false)
   end
 
@@ -55,27 +55,27 @@ defmodule Bank.Users do
 
   ## Examples
 
-      iex> delete_user(user)
+      iex> delete(user)
       {:ok, %User{}}
 
-      iex> delete_user(user)
+      iex> delete(user)
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec delete_user(Ecto.Schema.t()) :: EctoUtils.write()
-  def delete_user(%User{} = user), do: Repo.delete(user)
+  @spec delete(Ecto.Schema.t()) :: EctoUtils.write()
+  def delete(%User{} = user), do: Repo.delete(user)
 
   @doc ~S"""
   Delivers the reset password email to the given user.
 
   ## Examples
 
-      iex> deliver_user_reset_password_instructions(user, &url(~p"/users/reset_password/#{&1}"))
+      iex> deliver_reset_password_instructions(user, &url(~p"/users/reset_password/#{&1}"))
       {:ok, %{to: ..., body: ...}}
 
   """
-  @spec deliver_user_reset_password_instructions(Ecto.Schema.t(), fun()) :: UserNotifier.t()
-  def deliver_user_reset_password_instructions(%User{} = user, reset_password_url_fun)
+  @spec deliver_reset_password_instructions(Ecto.Schema.t(), fun()) :: UserNotifier.t()
+  def deliver_reset_password_instructions(%User{} = user, reset_password_url_fun)
       when is_function(reset_password_url_fun, 1) do
     {encoded_token, user_token} = UserToken.build_email_token(user, "reset_password")
     Repo.insert!(user_token)
@@ -89,30 +89,30 @@ defmodule Bank.Users do
 
   ## Examples
 
-      iex> get_user!(123)
+      iex> get!(123)
       %User{}
 
-      iex> get_user!(456)
+      iex> get!(456)
       ** (Ecto.NoResultsError)
 
   """
-  @spec get_user!(pos_integer()) :: Ecto.Schema.t() | term()
-  def get_user!(id), do: Repo.get!(User, id)
+  @spec get!(pos_integer()) :: Ecto.Schema.t() | term()
+  def get!(id), do: Repo.get!(User, id)
 
   @doc """
   Gets a user by email.
 
   ## Examples
 
-      iex> get_user_by_email("foo@example.com")
+      iex> get_by_email("foo@example.com")
       %User{}
 
-      iex> get_user_by_email("unknown@example.com")
+      iex> get_by_email("unknown@example.com")
       nil
 
   """
-  @spec get_user_by_email(binary()) :: EctoUtils.get()
-  def get_user_by_email(email) when is_binary(email) do
+  @spec get_by_email(binary()) :: EctoUtils.get()
+  def get_by_email(email) when is_binary(email) do
     Repo.get_by(User, email: email)
   end
 
@@ -121,15 +121,15 @@ defmodule Bank.Users do
 
   ## Examples
 
-      iex> get_user_by_email_and_password("foo@example.com", "correct_password")
+      iex> get_by_email_and_password("foo@example.com", "correct_password")
       %User{}
 
-      iex> get_user_by_email_and_password("foo@example.com", "invalid_password")
+      iex> get_by_email_and_password("foo@example.com", "invalid_password")
       nil
 
   """
-  @spec get_user_by_email_and_password(binary(), binary()) :: EctoUtils.get()
-  def get_user_by_email_and_password(email, password)
+  @spec get_by_email_and_password(binary(), binary()) :: EctoUtils.get()
+  def get_by_email_and_password(email, password)
       when is_binary(email) and is_binary(password) do
     user = Repo.get_by(User, email: email)
     if User.valid_password?(user, password), do: user
@@ -140,15 +140,15 @@ defmodule Bank.Users do
 
   ## Examples
 
-      iex> get_user_by_reset_password_token("validtoken")
+      iex> get_by_reset_password_token("validtoken")
       %User{}
 
-      iex> get_user_by_reset_password_token("invalidtoken")
+      iex> get_by_reset_password_token("invalidtoken")
       nil
 
   """
-  @spec get_user_by_reset_password_token(binary()) :: Ecto.Schema.t() | nil
-  def get_user_by_reset_password_token(token) do
+  @spec get_by_reset_password_token(binary()) :: Ecto.Schema.t() | nil
+  def get_by_reset_password_token(token) do
     with {:ok, query} <- UserToken.verify_email_token_query(token, "reset_password"),
          %User{} = user <- Repo.one(query) do
       user
@@ -193,16 +193,16 @@ defmodule Bank.Users do
 
   ## Examples
 
-      iex> reset_user_password(user, %{password: "new long password", password_confirmation: "new long password"})
+      iex> reset_password(user, %{password: "new long password", password_confirmation: "new long password"})
       {:ok, %User{}}
 
-      iex> reset_user_password(user, %{password: "valid", password_confirmation: "not the same"})
+      iex> reset_password(user, %{password: "valid", password_confirmation: "not the same"})
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec reset_user_password(Ecto.Schema.t(), map()) ::
-          {:ok | :error, Ecto.Schema.t() | Ecto.Changeset.t()}
-  def reset_user_password(user, attrs) do
+  @spec reset_password(Ecto.Schema.t(), map()) ::
+          {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
+  def reset_password(user, attrs) do
     ecto_multi =
       Ecto.Multi.new()
       |> Ecto.Multi.update(:user, User.password_changeset(user, attrs))

--- a/lib/bank/users_sessions.ex
+++ b/lib/bank/users_sessions.ex
@@ -29,8 +29,8 @@ defmodule Bank.UsersSessions do
   @doc """
   Deletes the signed token with the given context.
   """
-  @spec delete_user_session_token(binary()) :: :ok
-  def delete_user_session_token(token) do
+  @spec delete_session_token(binary()) :: :ok
+  def delete_session_token(token) do
     token
     |> UserToken.by_token_and_context_query("session")
     |> Repo.delete_all()

--- a/lib/bank_web/controllers/user_confirmation_controller.ex
+++ b/lib/bank_web/controllers/user_confirmation_controller.ex
@@ -12,7 +12,7 @@ defmodule BankWeb.UserConfirmationController do
 
   @spec create(Conn.t(), map()) :: Conn.t()
   def create(conn, %{"user" => %{"email" => email}}) do
-    if user = Users.get_user_by_email(email) do
+    if user = Users.get_by_email(email) do
       UsersSessions.deliver_user_confirmation_instructions(
         user,
         &url(~p"/users/confirm/#{&1}")

--- a/lib/bank_web/controllers/user_registration_controller.ex
+++ b/lib/bank_web/controllers/user_registration_controller.ex
@@ -9,7 +9,7 @@ defmodule BankWeb.UserRegistrationController do
 
   @spec new(Conn.t(), map()) :: Conn.t()
   def new(conn, _params) do
-    changeset = Users.change_user_registration(%User{})
+    changeset = Users.change_registration(%User{})
     render(conn, :new, changeset: changeset)
   end
 

--- a/lib/bank_web/controllers/user_reset_password_controller.ex
+++ b/lib/bank_web/controllers/user_reset_password_controller.ex
@@ -4,7 +4,7 @@ defmodule BankWeb.UserResetPasswordController do
   alias Bank.Users
   alias Plug.Conn
 
-  plug :get_user_by_reset_password_token when action in [:edit, :update]
+  plug :get_by_reset_password_token when action in [:edit, :update]
 
   @spec new(Conn.t(), map()) :: Conn.t()
   def new(conn, _params) do
@@ -13,8 +13,8 @@ defmodule BankWeb.UserResetPasswordController do
 
   @spec create(Conn.t(), map()) :: Conn.t()
   def create(conn, %{"user" => %{"email" => email}}) do
-    if user = Users.get_user_by_email(email) do
-      Users.deliver_user_reset_password_instructions(
+    if user = Users.get_by_email(email) do
+      Users.deliver_reset_password_instructions(
         user,
         &url(~p"/users/reset_password/#{&1}")
       )
@@ -30,14 +30,14 @@ defmodule BankWeb.UserResetPasswordController do
 
   @spec edit(Conn.t(), map()) :: Conn.t()
   def edit(conn, _params) do
-    render(conn, :edit, changeset: Users.change_user_password(conn.assigns.user))
+    render(conn, :edit, changeset: Users.change_password(conn.assigns.user))
   end
 
   # Do not log in the user after reset password to avoid a
   # leaked token giving the user access to the account.
   @spec update(Conn.t(), map()) :: Conn.t()
   def update(conn, %{"user" => user_params}) do
-    case Users.reset_user_password(conn.assigns.user, user_params) do
+    case Users.reset_password(conn.assigns.user, user_params) do
       {:ok, _} ->
         conn
         |> put_flash(:info, "Password reset successfully.")
@@ -48,11 +48,11 @@ defmodule BankWeb.UserResetPasswordController do
     end
   end
 
-  @spec get_user_by_reset_password_token(Conn.t(), keyword()) :: Conn.t()
-  defp get_user_by_reset_password_token(conn, _opts) do
+  @spec get_by_reset_password_token(Conn.t(), keyword()) :: Conn.t()
+  defp get_by_reset_password_token(conn, _opts) do
     %{"token" => token} = conn.params
 
-    if user = Users.get_user_by_reset_password_token(token) do
+    if user = Users.get_by_reset_password_token(token) do
       conn
       |> assign(:user, user)
       |> assign(:token, token)

--- a/lib/bank_web/controllers/user_session_controller.ex
+++ b/lib/bank_web/controllers/user_session_controller.ex
@@ -31,7 +31,7 @@ defmodule BankWeb.UserSessionController do
   # defp create(conn, %{"user" => user_params}, info) do
   #   %{"email" => email, "password" => password} = user_params
 
-  #   if user = Users.get_user_by_email_and_password(email, password) do
+  #   if user = Users.get_by_email_and_password(email, password) do
   #     conn
   #     |> put_flash(:info, info)
   #     |> UserAuth.log_in_user(user, user_params)
@@ -52,7 +52,7 @@ defmodule BankWeb.UserSessionController do
   def create(conn, %{"user" => user_params}) do
     %{"email" => email, "password" => password} = user_params
 
-    if user = Users.get_user_by_email_and_password(email, password) do
+    if user = Users.get_by_email_and_password(email, password) do
       conn
       |> put_flash(:info, "Welcome back!")
       |> UserAuth.log_in_user(user, user_params)

--- a/lib/bank_web/controllers/user_settings_controller.ex
+++ b/lib/bank_web/controllers/user_settings_controller.ex
@@ -76,6 +76,6 @@ defmodule BankWeb.UserSettingsController do
 
     conn
     |> assign(:email_changeset, UsersSettings.change_user_email(user))
-    |> assign(:password_changeset, Users.change_user_password(user))
+    |> assign(:password_changeset, Users.change_password(user))
   end
 end

--- a/lib/bank_web/live/admin/user_live/index.ex
+++ b/lib/bank_web/live/admin/user_live/index.ex
@@ -12,8 +12,8 @@ defmodule BankWeb.Headquarters.UserLive.Index do
 
   @impl LiveView
   def handle_event("delete", %{"id" => id}, socket) do
-    user = Users.get_user!(id)
-    {:ok, _} = Users.delete_user(user)
+    user = Users.get!(id)
+    {:ok, _} = Users.delete(user)
 
     {:noreply, stream_delete(socket, :users, user)}
   end
@@ -32,7 +32,7 @@ defmodule BankWeb.Headquarters.UserLive.Index do
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
     |> assign(:page_title, "Edit User")
-    |> assign(:user, Users.get_user!(id))
+    |> assign(:user, Users.get!(id))
   end
 
   defp apply_action(socket, :index, _params) do

--- a/lib/bank_web/live/admin/user_live/show.ex
+++ b/lib/bank_web/live/admin/user_live/show.ex
@@ -15,7 +15,7 @@ defmodule BankWeb.Headquarters.UserLive.Show do
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:user, Users.get_user!(id))}
+     |> assign(:user, Users.get!(id))}
   end
 
   defp page_title(:show), do: "Show User"

--- a/lib/bank_web/user_auth.ex
+++ b/lib/bank_web/user_auth.ex
@@ -62,7 +62,7 @@ defmodule BankWeb.UserAuth do
   @spec log_out_user(Conn.t()) :: Conn.t()
   def log_out_user(conn) do
     user_token = get_session(conn, :user_token)
-    user_token && UsersSessions.delete_user_session_token(user_token)
+    user_token && UsersSessions.delete_session_token(user_token)
 
     if live_socket_id = get_session(conn, :live_socket_id) do
       BankWeb.Endpoint.broadcast(live_socket_id, "disconnect", %{})

--- a/test/bank/users_sessions_test.exs
+++ b/test/bank/users_sessions_test.exs
@@ -41,11 +41,11 @@ defmodule Bank.UsersSessionsTest do
     end
   end
 
-  describe "delete_user_session_token/1" do
+  describe "delete_session_token/1" do
     test "deletes the token" do
       user = UsersFixtures.fixture()
       token = UsersSessions.generate_user_session_token(user)
-      assert UsersSessions.delete_user_session_token(token) == :ok
+      assert UsersSessions.delete_session_token(token) == :ok
       refute UsersSessions.get_user_by_session_token(token)
     end
   end

--- a/test/bank/users_settings_test.exs
+++ b/test/bank/users_settings_test.exs
@@ -68,7 +68,7 @@ defmodule Bank.UsersSettingsTest do
         UsersSettings.apply_user_email(user, UsersFixtures.valid_user_password(), %{email: email})
 
       assert user.email == email
-      assert Users.get_user!(user.id).email != email
+      assert Users.get!(user.id).email != email
     end
   end
 
@@ -79,15 +79,15 @@ defmodule Bank.UsersSettingsTest do
     end
   end
 
-  describe "change_user_password/2" do
+  describe "change_password/2" do
     test "returns a user changeset" do
-      assert %Ecto.Changeset{} = changeset = Users.change_user_password(%User{})
+      assert %Ecto.Changeset{} = changeset = Users.change_password(%User{})
       assert changeset.required == [:password]
     end
 
     test "allows fields to be set" do
       changeset =
-        Users.change_user_password(%User{}, %{
+        Users.change_password(%User{}, %{
           "password" => @new_valid_password
         })
 
@@ -214,7 +214,7 @@ defmodule Bank.UsersSettingsTest do
         })
 
       assert is_nil(user.password)
-      assert Users.get_user_by_email_and_password(user.email, @new_valid_password)
+      assert Users.get_by_email_and_password(user.email, @new_valid_password)
     end
 
     test "deletes all tokens for the given user", %{user: user} do

--- a/test/bank_web/controllers/user_confirmation_controller_test.exs
+++ b/test/bank_web/controllers/user_confirmation_controller_test.exs
@@ -91,7 +91,7 @@ defmodule BankWeb.UserConfirmationControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
                "User confirmed successfully"
 
-      assert Users.get_user!(user.id).confirmed_at
+      assert Users.get!(user.id).confirmed_at
       refute get_session(conn, :user_token)
       assert Repo.all(Users.UserToken) == []
 
@@ -119,7 +119,7 @@ defmodule BankWeb.UserConfirmationControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
                "User confirmation link is invalid or it has expired"
 
-      refute Users.get_user!(user.id).confirmed_at
+      refute Users.get!(user.id).confirmed_at
     end
   end
 end

--- a/test/bank_web/controllers/user_reset_password_controller_test.exs
+++ b/test/bank_web/controllers/user_reset_password_controller_test.exs
@@ -54,7 +54,7 @@ defmodule BankWeb.UserResetPasswordControllerTest do
     setup %{user: user} do
       token =
         UsersFixtures.extract_user_token(fn url ->
-          Users.deliver_user_reset_password_instructions(user, url)
+          Users.deliver_reset_password_instructions(user, url)
         end)
 
       %{token: token}
@@ -78,7 +78,7 @@ defmodule BankWeb.UserResetPasswordControllerTest do
     setup %{user: user} do
       token =
         UsersFixtures.extract_user_token(fn url ->
-          Users.deliver_user_reset_password_instructions(user, url)
+          Users.deliver_reset_password_instructions(user, url)
         end)
 
       %{token: token}
@@ -99,7 +99,7 @@ defmodule BankWeb.UserResetPasswordControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
                "Password reset successfully"
 
-      assert Users.get_user_by_email_and_password(user.email, @new_valid_password)
+      assert Users.get_by_email_and_password(user.email, @new_valid_password)
     end
 
     test "does not reset password on invalid data", %{conn: conn, token: token} do

--- a/test/bank_web/controllers/user_settings_controller_test.exs
+++ b/test/bank_web/controllers/user_settings_controller_test.exs
@@ -43,7 +43,7 @@ defmodule BankWeb.UserSettingsControllerTest do
       assert Phoenix.Flash.get(new_password_conn.assigns.flash, :info) =~
                "Password updated successfully"
 
-      assert Users.get_user_by_email_and_password(user.email, @new_valid_password)
+      assert Users.get_by_email_and_password(user.email, @new_valid_password)
     end
 
     test "does not update password on invalid data", %{conn: conn} do
@@ -82,7 +82,7 @@ defmodule BankWeb.UserSettingsControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
                "A link to confirm your email"
 
-      assert Users.get_user_by_email(user.email)
+      assert Users.get_by_email(user.email)
     end
 
     test "does not update email on invalid data", %{conn: conn} do
@@ -123,8 +123,8 @@ defmodule BankWeb.UserSettingsControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
                "Email changed successfully"
 
-      refute Users.get_user_by_email(user.email)
-      assert Users.get_user_by_email(email)
+      refute Users.get_by_email(user.email)
+      assert Users.get_by_email(email)
 
       conn = get(conn, ~p"/users/settings/confirm_email/#{token}")
 
@@ -141,7 +141,7 @@ defmodule BankWeb.UserSettingsControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
                "Email change link is invalid or it has expired"
 
-      assert Users.get_user_by_email(user.email)
+      assert Users.get_by_email(user.email)
     end
 
     test "redirects if user is not logged in", %{token: token} do


### PR DESCRIPTION
# Why the PR is required?

Include name "user" Users context functions name is unnecessary, you already know it is something related to users.
