### PR TITLE
Autofill just when opened

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,13 @@
 
 Explanation of the problem this PR solves and why it is necessary.
 
-## Added to the PR
+## Added by the PR
+
+- List of new features, bug fixes, or changes introduced by this PR.
+- Keep descriptions clear and concise.
+- **Example**: this is an feature.
+
+## Updated by the PR
 
 - List of new features, bug fixes, or changes introduced by this PR.
 - Keep descriptions clear and concise.

--- a/.github/workflows/pr-autofill-information.yml
+++ b/.github/workflows/pr-autofill-information.yml
@@ -2,7 +2,7 @@ name: Label, Assignee and Set PR Title
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened]
 
 jobs:
   set-title:


### PR DESCRIPTION
# Why the PR is required?

The autofill was executed on each push which is unnecessary.
